### PR TITLE
Dont enable gcp apis

### DIFF
--- a/modules/gh-runner-mig-vm/main.tf
+++ b/modules/gh-runner-mig-vm/main.tf
@@ -24,26 +24,6 @@ locals {
 }
 
 /*****************************************
-  Activate Services in Runner Project
- *****************************************/
-module "enables-google-apis" {
-  source  = "terraform-google-modules/project-factory/google//modules/project_services"
-  version = "6.0.0"
-
-  project_id = var.project_id
-
-  activate_apis = [
-    "iam.googleapis.com",
-    "compute.googleapis.com",
-    "storage-component.googleapis.com",
-    "logging.googleapis.com",
-    "monitoring.googleapis.com",
-    "secretmanager.googleapis.com",
-  ]
-}
-
-
-/*****************************************
   Optional Runner Networking
  *****************************************/
 resource "google_compute_network" "gh-network" {


### PR DESCRIPTION
Removed the code which enabled GCP APIs, so that removing this module doesn't disable those APIs implicitly.

Please understand I've not been able to test this as the test suite says it requires the Project Creator permission, and since I only need to use the gh-runner-mig-vm module that's the only one I've applied this change to as it's the only one I've been able to test in my local environment. 

Given unlimited resources I would gladly make this change to each of the modules in this repo, I apologize. 

This should resolve #5 