### PR TITLE
Fix links from module READMEs to examples

### DIFF
--- a/modules/gh-runner-gke/README.md
+++ b/modules/gh-runner-gke/README.md
@@ -11,11 +11,11 @@ This includes:
 
 Below are some examples:
 
-### [Self Hosted runners on GKE that support Docker workflows](examples/gh-runner-gke-dind/README.md)
+### [Self Hosted runners on GKE that support Docker workflows](../../examples/gh-runner-gke-dind/README.md)
 
 This example shows how to deploy Self Hosted Runners on GKE that supports Docker Workflows.
 
-### [Simple Self Hosted Runners on GKE](examples/gh-runner-gke-simple/README.md)
+### [Simple Self Hosted Runners on GKE](../../examples/gh-runner-gke-simple/README.md)
 
 This example shows how to deploy a simple GKE Self Hosted Runner.
 

--- a/modules/gh-runner-mig-container-vm/README.md
+++ b/modules/gh-runner-mig-container-vm/README.md
@@ -13,11 +13,11 @@ This includes:
 
 Below are some examples:
 
-### [Self Hosted runners that support Docker Workflows](examples/gh-runner-mig-container-vm-dind/README.md)
+### [Self Hosted runners that support Docker Workflows](../../examples/gh-runner-mig-container-vm-dind/README.md)
 
 This example shows how to deploy a Self Hosted Runner that supports Docker Workflows on MIG Container VMs.
 
-### [Simple Self Hosted Runner](examples/gh-runner-mig-container-vm-simple/README.md)
+### [Simple Self Hosted Runner](../../examples/gh-runner-mig-container-vm-simple/README.md)
 
 This example shows how to deploy a Self Hosted Runner on MIG Container VMs.
 

--- a/modules/gh-runner-mig-vm/README.md
+++ b/modules/gh-runner-mig-vm/README.md
@@ -15,11 +15,11 @@ This includes:
 
 Below are some examples:
 
-### [Simple Self Hosted Runner](examples/gh-runner-mig-native-simple/README.md)
+### [Simple Self Hosted Runner](../../examples/gh-runner-mig-native-simple/README.md)
 
 This example shows how to deploy a MIG Self Hosted Runner bootstrapped using startup scripts.
 
-### [Simple Self Hosted Runner](examples/gh-runner-mig-native-packer/README.md)
+### [Simple Self Hosted Runner](../../examples/gh-runner-mig-native-packer/README.md)
 
 This example shows how to deploy a MIG Self Hosted Runner with an image pre-baked using Packer.
 


### PR DESCRIPTION
* links from module README files to examples were broken
* added ../../ in front of links to fix them