### PR TITLE
fix: use machine_type in mig-runner

### DIFF
--- a/modules/gh-runner-mig-vm/README.md
+++ b/modules/gh-runner-mig-vm/README.md
@@ -34,7 +34,7 @@ This example shows how to deploy a MIG Self Hosted Runner with an image pre-bake
 | custom\_metadata | User provided custom metadata | `map` | `{}` | no |
 | gh\_token | Github token that is used for generating Self Hosted Runner Token | `string` | n/a | yes |
 | instance\_name | The gce instance name | `string` | `"gh-runner"` | no |
-| machine\_type | The GCP machine type to deploy | `string` | `"n1-standard-4"` | no |
+| machine\_type | The GCP machine type to deploy | `string` | `"n1-standard-1"` | no |
 | network\_name | Name for the VPC network | `string` | `"gh-runner-network"` | no |
 | project\_id | The project id to deploy Github Runner | `string` | n/a | yes |
 | region | The GCP region to deploy instances into | `string` | `"us-east4"` | no |

--- a/modules/gh-runner-mig-vm/main.tf
+++ b/modules/gh-runner-mig-vm/main.tf
@@ -125,6 +125,7 @@ module "mig_template" {
   source             = "terraform-google-modules/vm/google//modules/instance_template"
   version            = "~> 5.0"
   project_id         = var.project_id
+  machine_type       = var.machine_type
   network            = local.network_name
   subnetwork         = local.subnet_name
   region             = var.region

--- a/modules/gh-runner-mig-vm/variables.tf
+++ b/modules/gh-runner-mig-vm/variables.tf
@@ -111,7 +111,7 @@ variable "additional_metadata" {
 variable "machine_type" {
   type        = string
   description = "The GCP machine type to deploy"
-  default     = "n1-standard-4"
+  default     = "n1-standard-1"
 }
 
 variable "source_image_family" {


### PR DESCRIPTION
fixes #21 
- use machine_type in mig-runner
- switching default to n1-standard-1 to align with upstream default to prevent a breaking release