### PR TITLE
Support organisation runners & add more variables.

### DIFF
--- a/modules/gh-runner-mig-vm/variables.tf
+++ b/modules/gh-runner-mig-vm/variables.tf
@@ -53,6 +53,13 @@ variable "subnet_ip" {
   description = "IP range for the subnet"
   default     = "10.10.10.0/24"
 }
+
+variable "create_subnetwork" {
+  type        = bool
+  description = "Whether to create subnetwork or use the one provided via subnet_name"
+  default     = true
+}
+
 variable "subnet_name" {
   type        = string
   description = "Name for the subnet"
@@ -68,17 +75,35 @@ variable "restart_policy" {
 variable "repo_url" {
   type        = string
   description = "Repo URL for the Github Action"
+  default     = ""
 }
 
 variable "repo_name" {
   type        = string
   description = "Name of the repo for the Github Action"
+  default     = ""
 }
-
 
 variable "repo_owner" {
   type        = string
   description = "Owner of the repo for the Github Action"
+}
+
+variable "labels" {
+  type        = set(string)
+  description = "Labels to attach to the runners"
+}
+
+variable "min_replicas" {
+  type        = number
+  description = "Minimum number of runner instances"
+  default     = 2
+}
+
+variable "max_replicas" {
+  type        = number
+  default     = 10
+  description = "Maximum number of runner instances"
 }
 
 variable "gh_token" {
@@ -90,12 +115,6 @@ variable "instance_name" {
   type        = string
   description = "The gce instance name"
   default     = "gh-runner"
-}
-
-variable "target_size" {
-  type        = number
-  description = "The number of runner instances"
-  default     = 2
 }
 
 variable "service_account" {
@@ -123,7 +142,7 @@ variable "source_image_family" {
 variable "source_image_project" {
   type        = string
   description = "Project where the source image comes from"
-  default     = "gce-uefi-images"
+  default     = "ubuntu-os-cloud"
 }
 
 variable "source_image" {


### PR DESCRIPTION
@maintainers, thanks for the base work!

We needed Organisation Runners and followed the advice in this discussion (https://github.com/terraform-google-modules/terraform-google-github-actions-runners/issues/3) to make the necessary changes.
Had to make `repo_url` & `repo_name` optional to support Organisation Runners. If `repo_name` is empty, organisation runners are registered.

We also added the ability to customize few other parameters like:
1. Ability to provide `network` but still let the module create `sub-network`
2. Ability to pass `region` instead of hardcoding it to `US`. Happy to change this to a list and then add `dynamic` block if needed.
3. Ability to pass `labels` to the module that the runners can be tagged with during registration.
4. Bug - The `target_size` should not be specified as autoscaling is enabled. From the [managed-instance-group](https://github.com/terraform-google-modules/terraform-google-vm/tree/v7.1.0/modules/mig) docs -
>  target_size | The target number of running instances for this managed instance group. This value should always be explicitly set unless this resource is attached to an autoscaler, in which case it should never be set.
5. Instead of above, added support for `min_replicas` & `max_replicas`.
6. Updated `source_image_project` from the deprecated `gce-uefi-images` family.
7. Updated to the latest version of github action `2.283.2`

If the changes make sense, it would be nice to get them merged into the module. 
Happy to receive any feedbacks.


