### PR TITLE
Remove the default allowed audience in `gh-oidc`

### DIFF
--- a/modules/gh-oidc/README.md
+++ b/modules/gh-oidc/README.md
@@ -68,7 +68,7 @@ jobs:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| allowed\_audiences | Workload Identity Pool Provider allowed audiences. Currently, GitHub only allows sigstore | `list(string)` | <pre>[<br>  "sigstore"<br>]</pre> | no |
+| allowed\_audiences | Workload Identity Pool Provider allowed audiences. | `list(string)` | `[]` | no |
 | attribute\_condition | Workload Identity Pool Provider attribute condition expression. [More info](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool_provider#attribute_condition) | `string` | `null` | no |
 | attribute\_mapping | Workload Identity Pool Provider attribute mapping. [More info](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool_provider#attribute_mapping) | `map(any)` | <pre>{<br>  "attribute.actor": "assertion.actor",<br>  "attribute.aud": "assertion.aud",<br>  "attribute.repository": "assertion.repository",<br>  "google.subject": "assertion.sub"<br>}</pre> | no |
 | pool\_description | Workload Identity Pool description | `string` | `"Workload Identity Pool managed by Terraform"` | no |

--- a/modules/gh-oidc/variables.tf
+++ b/modules/gh-oidc/variables.tf
@@ -72,8 +72,8 @@ variable "attribute_mapping" {
 
 variable "allowed_audiences" {
   type        = list(string)
-  description = "Workload Identity Pool Provider allowed audiences. Currently, GitHub only allows sigstore"
-  default     = ["sigstore"]
+  description = "Workload Identity Pool Provider allowed audiences."
+  default     = []
 }
 
 variable "sa_mapping" {

--- a/test/integration/oidc-simple/oidc_simple_test.go
+++ b/test/integration/oidc-simple/oidc_simple_test.go
@@ -34,8 +34,7 @@ func TestOIDCSimple(t *testing.T) {
 		provider := gcloud.Run(t, fmt.Sprintf("beta iam workload-identity-pools providers describe %s", oidc.GetStringOutput("provider_name")))
 		assert.Equal("ACTIVE", provider.Get("state").String(), "WI provider is active")
 		assert.Equal("https://token.actions.githubusercontent.com", provider.Get("oidc.issuerUri").String(), "provider has correct issuer ID")
-		assert.Equal(1, len(provider.Get("oidc.allowedAudiences").Array()), "WI provider has correct number of audiences")
-		assert.Equal("sigstore", provider.Get("oidc.allowedAudiences").Array()[0].String(), "WI provider has correct audience")
+		assert.Equal(0, len(provider.Get("oidc.allowedAudiences").Array()), "WI provider has correct number of audiences")
 		expectedAttribMapping := map[string]string{
 			"attribute.actor":      "assertion.actor",
 			"attribute.aud":        "assertion.aud",


### PR DESCRIPTION
## Overview
The official version of GitHub OpenID connection no longer requires `audience=sigstore`. So, the default value of `allowed_audiences` can be an empty list.
https://docs.github.com/ja/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-google-cloud-platform