### PR TITLE
Change the format of `service_account_id` in `wif-sa`

### DIFF
--- a/modules/gh-oidc/main.tf
+++ b/modules/gh-oidc/main.tf
@@ -40,7 +40,7 @@ resource "google_iam_workload_identity_pool_provider" "main" {
 
 resource "google_service_account_iam_member" "wif-sa" {
   for_each           = var.sa_mapping
-  service_account_id = each.value.sa_name
+  service_account_id = "projects/${var.project_id}/serviceAccounts/${each.value.sa_name}"
   role               = "roles/iam.workloadIdentityUser"
   member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.main.name}/${each.value.attribute}"
 }


### PR DESCRIPTION
## Overview
We have to pass the full ID of a service account, not only an email.

```bash
Error: "service_account_id" ("service-account@my-project.iam.gserviceaccount.com") doesn't match regexp "projects/(?:(?:[-a-z0-9]{1,63}\\.)*(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?):)?(?:[0-9]{1,19}|(?:[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?)|-)/serviceAccounts/((?:(?:[-a-z0-9]{1,63}\\.)*(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?):)?(?:[0-9]{1,19}|(?:[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?))@[a-z]+.gserviceaccount.com$|[0-9]{1,20}-compute@developer.gserviceaccount.com|[a-z](?:[-a-z0-9]{4,28}[a-z0-9])@[-a-z0-9\\.]{1,63}\\.iam\\.gserviceaccount\\.com$)"
```