### PR TITLE
docs: fix sa_name example & description

### DIFF
--- a/modules/gh-oidc/README.md
+++ b/modules/gh-oidc/README.md
@@ -18,7 +18,7 @@ module "gh_oidc" {
   provider_id = "example-gh-provider"
   sa_mapping = {
     "foo-service-account" = {
-      sa_name   = "foo-service-account@my-project.iam.gserviceaccount.com"
+      sa_name   = "projects/my-project/serviceAccounts/foo-service-account@my-project.iam.gserviceaccount.com"
       attribute = "attribute.repository/user/repo"
     }
   }

--- a/modules/gh-oidc/README.md
+++ b/modules/gh-oidc/README.md
@@ -78,7 +78,7 @@ jobs:
 | provider\_description | Workload Identity Pool Provider description | `string` | `"Workload Identity Pool Provider managed by Terraform"` | no |
 | provider\_display\_name | Workload Identity Pool Provider display name | `string` | `null` | no |
 | provider\_id | Workload Identity Pool Provider id | `string` | n/a | yes |
-| sa\_mapping | Service Account emails and corresponding WIF provider attributes. If attribute is set to `*` all identities in the pool are granted access to SAs. | <pre>map(object({<br>    sa_name   = string<br>    attribute = string<br>  }))</pre> | `{}` | no |
+| sa\_mapping | Service Account resource names and corresponding WIF provider attributes. If attribute is set to `*` all identities in the pool are granted access to SAs. | <pre>map(object({<br>    sa_name   = string<br>    attribute = string<br>  }))</pre> | `{}` | no |
 
 ## Outputs
 

--- a/modules/gh-oidc/variables.tf
+++ b/modules/gh-oidc/variables.tf
@@ -81,6 +81,6 @@ variable "sa_mapping" {
     sa_name   = string
     attribute = string
   }))
-  description = "Service Account emails and corresponding WIF provider attributes. If attribute is set to `*` all identities in the pool are granted access to SAs."
+  description = "Service Account resource names and corresponding WIF provider attributes. If attribute is set to `*` all identities in the pool are granted access to SAs."
   default     = {}
 }


### PR DESCRIPTION
Sorry for my trivial PR again.

`sa_name` in gh-oidc module doesn't expect an email address of service accounts.
It passes to google_service_account_iam_member, which is a resource name like `projects/{project_id}/serviceAccounts/{email}`.