### PR TITLE
Honor instance_name in gh-runner-mig-vm

### DIFF
--- a/modules/gh-runner-mig-vm/main.tf
+++ b/modules/gh-runner-mig-vm/main.tf
@@ -113,7 +113,7 @@ resource "google_secret_manager_secret_iam_member" "gh-secret-member" {
   Runner GCE Instance Template
  *****************************************/
 locals {
-  instance_name = "gh-runner-vm"
+  instance_name = var.instance_name
 }
 
 

--- a/modules/gh-runner-mig-vm/variables.tf
+++ b/modules/gh-runner-mig-vm/variables.tf
@@ -109,7 +109,7 @@ variable "gh_token" {
 variable "instance_name" {
   type        = string
   description = "The gce instance name"
-  default     = "gh-runner"
+  default     = "gh-runner-vm"
 }
 
 variable "service_account" {


### PR DESCRIPTION
The `instance_name` was statically set, and the variable was ignored. This fixes that, and changes the default to keep the expected behavior without `instance_name` set.