### PR TITLE
additional startup script options

### DIFF
--- a/modules/gh-runner-mig-container-vm/README.md
+++ b/modules/gh-runner-mig-container-vm/README.md
@@ -46,6 +46,7 @@ This example shows how to deploy a Self Hosted Runner on MIG Container VMs.
 | subnet\_name | Name for the subnet | `string` | `"gh-runner-subnet"` | no |
 | subnetwork\_project | The ID of the project in which the subnetwork belongs. If it is not provided, the project\_id is used. | `string` | `""` | no |
 | target\_size | The number of runner instances | `number` | `2` | no |
+| update\_policy | Update policy for the MIG. See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_instance_group_manager#nested_update_policy | `list` | `[]` | no |
 | zone | The GCP zone to deploy instances into | `string` | `"us-east4-b"` | no |
 
 ## Outputs

--- a/modules/gh-runner-mig-container-vm/main.tf
+++ b/modules/gh-runner-mig-container-vm/main.tf
@@ -194,4 +194,5 @@ module "mig" {
   /* autoscaler */
   autoscaling_enabled = true
   cooldown_period     = var.cooldown_period
+  update_policy       = var.update_policy
 }

--- a/modules/gh-runner-mig-container-vm/variables.tf
+++ b/modules/gh-runner-mig-container-vm/variables.tf
@@ -133,5 +133,5 @@ variable "cooldown_period" {
 
 variable "update_policy" {
   description = "Update policy for the MIG. See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_instance_group_manager#nested_update_policy"
-  default = []
+  default     = []
 }

--- a/modules/gh-runner-mig-container-vm/variables.tf
+++ b/modules/gh-runner-mig-container-vm/variables.tf
@@ -18,6 +18,7 @@ variable "project_id" {
   type        = string
   description = "The project id to deploy Github Runner"
 }
+
 variable "region" {
   type        = string
   description = "The GCP region to deploy instances into"
@@ -128,4 +129,9 @@ variable "dind" {
 variable "cooldown_period" {
   description = "The number of seconds that the autoscaler should wait before it starts collecting information from a new instance."
   default     = 60
+}
+
+variable "update_policy" {
+  description = "Update policy for the MIG. See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_instance_group_manager#nested_update_policy"
+  default = []
 }

--- a/modules/gh-runner-mig-vm/README.md
+++ b/modules/gh-runner-mig-vm/README.md
@@ -51,9 +51,12 @@ This example shows how to deploy a MIG Self Hosted Runner with an image pre-bake
 | source\_image\_family | Source image family. If neither source\_image nor source\_image\_family is specified, defaults to the latest public Ubuntu image. | `string` | `"ubuntu-1804-lts"` | no |
 | source\_image\_project | Project where the source image comes from | `string` | `"ubuntu-os-cloud"` | no |
 | startup\_script | User startup script to run when instances spin up | `string` | `""` | no |
+| startup\_script\_post\_github\_runner\_setup | Additional commands to run after the startup script | `string` | `""` | no |
+| startup\_script\_pre\_github\_runner\_setup | Additional commands to run before the startup script | `string` | `""` | no |
 | subnet\_ip | IP range for the subnet | `string` | `"10.10.10.0/24"` | no |
 | subnet\_name | Name for the subnet | `string` | `"gh-runner-subnet"` | no |
 | subnetwork\_project | The ID of the project in which the subnetwork belongs. If it is not provided, the project\_id is used. | `string` | `""` | no |
+| update\_policy | Update policy for the MIG. See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_instance_group_manager#nested_update_policy | `list` | `[]` | no |
 | zone | The GCP zone to deploy instances into | `string` | `"us-east4-b"` | no |
 
 ## Outputs

--- a/modules/gh-runner-mig-vm/main.tf
+++ b/modules/gh-runner-mig-vm/main.tf
@@ -138,7 +138,11 @@ module "mig_template" {
   name_prefix          = "gh-runner"
   source_image_family  = var.source_image_family
   source_image_project = var.source_image_project
-  startup_script       = local.startup_script
+  startup_script       = <<EOT
+    ${var.startup_script_pre_github_runner_setup}
+    ${local.startup_script}
+    ${var.startup_script_post_github_runner_setup}
+  EOT
   source_image         = var.source_image
   metadata = merge({
     "secret-id" = google_secret_manager_secret_version.gh-secret-version.name
@@ -166,4 +170,6 @@ module "mig" {
   min_replicas        = var.min_replicas
   max_replicas        = var.max_replicas
   cooldown_period     = var.cooldown_period
+
+  update_policy       = var.update_policy
 }

--- a/modules/gh-runner-mig-vm/main.tf
+++ b/modules/gh-runner-mig-vm/main.tf
@@ -171,5 +171,5 @@ module "mig" {
   max_replicas        = var.max_replicas
   cooldown_period     = var.cooldown_period
 
-  update_policy       = var.update_policy
+  update_policy = var.update_policy
 }

--- a/modules/gh-runner-mig-vm/variables.tf
+++ b/modules/gh-runner-mig-vm/variables.tf
@@ -18,6 +18,7 @@ variable "project_id" {
   type        = string
   description = "The project id to deploy Github Runner"
 }
+
 variable "region" {
   type        = string
   description = "The GCP region to deploy instances into"
@@ -167,4 +168,21 @@ variable "custom_metadata" {
 variable "cooldown_period" {
   description = "The number of seconds that the autoscaler should wait before it starts collecting information from a new instance."
   default     = 60
+}
+
+variable "update_policy" {
+  description = "Update policy for the MIG. See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_instance_group_manager#nested_update_policy"
+  default = []
+}
+
+variable "startup_script_pre_github_runner_setup" {
+  type        = string
+  description = "Additional commands to run before the default startup script"
+  default     = ""
+}
+
+variable "startup_script_post_github_runner_setup" {
+  type        = string
+  description = "Additional command to run after the default startup script"
+  default     = ""
 }

--- a/modules/gh-runner-mig-vm/variables.tf
+++ b/modules/gh-runner-mig-vm/variables.tf
@@ -177,12 +177,12 @@ variable "update_policy" {
 
 variable "startup_script_pre_github_runner_setup" {
   type        = string
-  description = "Additional commands to run before the default startup script"
+  description = "Additional commands to run before the startup script"
   default     = ""
 }
 
 variable "startup_script_post_github_runner_setup" {
   type        = string
-  description = "Additional command to run after the default startup script"
+  description = "Additional commands to run after the startup script"
   default     = ""
 }

--- a/modules/gh-runner-mig-vm/variables.tf
+++ b/modules/gh-runner-mig-vm/variables.tf
@@ -172,7 +172,7 @@ variable "cooldown_period" {
 
 variable "update_policy" {
   description = "Update policy for the MIG. See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_instance_group_manager#nested_update_policy"
-  default = []
+  default     = []
 }
 
 variable "startup_script_pre_github_runner_setup" {


### PR DESCRIPTION
- Added variables to run custom commands before and after the default (provided) startup script

This is useful for (among others) actions that don't use docker to pull the required image. An example is [FairwindsOps/pluto](https://github.com/FairwindsOps/pluto). Their action uses podman instead.