### PR TITLE
Allowing preemptible vms for MIG

### DIFF
--- a/modules/gh-runner-mig-vm/main.tf
+++ b/modules/gh-runner-mig-vm/main.tf
@@ -140,6 +140,7 @@ module "mig_template" {
   source_image_project = var.source_image_project
   startup_script       = local.startup_script
   source_image         = var.source_image
+  preemptible          = var.preemptible
   metadata = merge({
     "secret-id" = google_secret_manager_secret_version.gh-secret-version.name
     }, {

--- a/modules/gh-runner-mig-vm/variables.tf
+++ b/modules/gh-runner-mig-vm/variables.tf
@@ -147,3 +147,9 @@ variable "cooldown_period" {
   type        = number
   default     = 60
 }
+
+variable "preemptible" {
+  description = "If set to true, then vms for the MIG will be preemptible"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Optional use of preemptible VMs in the MIG. Default value is false