### PR TITLE
feat: add the ability to enter custom GHA runner release version

### DIFF
--- a/modules/gh-runner-mig-vm/main.tf
+++ b/modules/gh-runner-mig-vm/main.tf
@@ -15,6 +15,7 @@
  */
 
 locals {
+  runner_version = var.runner_version == "" ? "2.283.2" : var.runner_version
   network_name    = var.create_network ? google_compute_network.gh-network[0].self_link : var.network_name
   subnet_name     = var.create_subnetwork ? google_compute_subnetwork.gh-subnetwork[0].self_link : var.subnet_name
   service_account = var.service_account == "" ? google_service_account.runner_service_account[0].email : var.service_account
@@ -141,7 +142,8 @@ module "mig_template" {
   startup_script       = local.startup_script
   source_image         = var.source_image
   metadata = merge({
-    "secret-id" = google_secret_manager_secret_version.gh-secret-version.name
+    "secret-id" = google_secret_manager_secret_version.gh-secret-version.name,
+    "runner-version" = local.runner_version
     }, {
     "shutdown-script" = local.shutdown_script
   }, var.custom_metadata)

--- a/modules/gh-runner-mig-vm/scripts/startup.sh
+++ b/modules/gh-runner-mig-vm/scripts/startup.sh
@@ -18,6 +18,7 @@ apt-get update
 apt-get -y install jq
 
 secretUri=$(curl -sS "http://metadata.google.internal/computeMetadata/v1/instance/attributes/secret-id" -H "Metadata-Flavor: Google")
+runnerVersion=$(curl -sS "http://metadata.google.internal/computeMetadata/v1/instance/attributes/runner-version" -H "Metadata-Flavor: Google")
 #secrets URI is of the form projects/$PROJECT_NUMBER/secrets/$SECRET_NAME/versions/$SECRET_VERSION
 #split into array based on `/` delimeter
 IFS="/" read -r -a secretsConfig <<<"$secretUri"
@@ -31,7 +32,7 @@ secrets=$(gcloud secrets versions access "$SECRET_VERSION" --secret="$SECRET_NAM
 # we want to use wordsplitting
 export $(echo "$secrets" | jq -r "to_entries|map(\"\(.key)=\(.value|tostring)\")|.[]")
 #github runner version
-GH_RUNNER_VERSION="2.283.2"
+GH_RUNNER_VERSION=${runnerVersion}
 #get actions binary
 curl -o actions.tar.gz --location "https://github.com/actions/runner/releases/download/v${GH_RUNNER_VERSION}/actions-runner-linux-x64-${GH_RUNNER_VERSION}.tar.gz"
 mkdir /runner

--- a/modules/gh-runner-mig-vm/variables.tf
+++ b/modules/gh-runner-mig-vm/variables.tf
@@ -147,3 +147,9 @@ variable "cooldown_period" {
   type        = number
   default     = 60
 }
+
+variable "runner_version" {
+  type = string
+  default = ""
+  description = "Release version of GitHub Actions runner that you would like to use"
+}


### PR DESCRIPTION
This lets you select a different GitHub Actions runner version rather than it being hard coded to v2.283.2. This was done due to a bug that was resolved in version 2.305.0.