### PR TITLE
feat: Add startup_script parameter to mig-container-vm runner

### DIFF
--- a/modules/gh-runner-mig-container-vm/main.tf
+++ b/modules/gh-runner-mig-container-vm/main.tf
@@ -169,7 +169,7 @@ module "mig_template" {
   name_prefix          = "gh-runner"
   source_image_family  = "cos-stable"
   source_image_project = "cos-cloud"
-  startup_script       = "export TEST_ENV='hello'"
+  startup_script       = var.startup_script
   source_image         = reverse(split("/", module.gce-container.source_image))[0]
   metadata             = merge(var.additional_metadata, { "gce-container-declaration" = module.gce-container.metadata_value })
   tags = [

--- a/modules/gh-runner-mig-container-vm/variables.tf
+++ b/modules/gh-runner-mig-container-vm/variables.tf
@@ -119,3 +119,9 @@ variable "cooldown_period" {
   type        = number
   default     = 60
 }
+
+variable "startup_script" {
+  description = "The startup script to run on the instance"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
 Adds `startup_script` var to container VM runner submodule. Very useful in case you want to configure Artifact Registry by setting the following script in the module config:
```yaml
  startup_script = "docker-credential-gcr configure-docker --registries ${var.region}-docker.pkg.dev"
```