### PR TITLE
fix: gke-simple - Update GH_RUNNER_VERSION

### DIFF
--- a/examples/gh-runner-gke-simple/Dockerfile
+++ b/examples/gh-runner-gke-simple/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && \
     tar \
     jq
 
-ARG GH_RUNNER_VERSION="2.169.0"
+ARG GH_RUNNER_VERSION="2.294.0"
 WORKDIR /runner
 RUN curl -o actions.tar.gz --location "https://github.com/actions/runner/releases/download/v${GH_RUNNER_VERSION}/actions-runner-linux-x64-${GH_RUNNER_VERSION}.tar.gz" && \
     tar -zxf actions.tar.gz && \


### PR DESCRIPTION
Ubuntu 22.04 (Jammy) uses `liblttng-ust1` instead of `liblttng-ust0` ([src](https://ubuntuforums.org/showthread.php?t=2477840&p=14107343#post14107343)) so `./bin/installdependencies.sh` fails.
 
https://github.com/actions/runner/issues/1584#issuecomment-1163340549 indicates that the minimum available version for the change in the build script is available in `v2.294.0`. This PR updates to use that version.