### PR TITLE
fix: set sensitive for gh-runner-gke ca_certificate output

### DIFF
--- a/modules/gh-runner-gke/outputs.tf
+++ b/modules/gh-runner-gke/outputs.tf
@@ -28,6 +28,7 @@ output "client_token" {
 
 output "ca_certificate" {
   description = "The cluster ca certificate (base64 encoded)"
+  sensitive   = true
   value       = module.runner-cluster.ca_certificate
 }
 


### PR DESCRIPTION
The `gh-runner-gke` module depends on `terraform-google-kubernetes-engine/beta-private-cluster` and passes through some of it's outputs. However the `ca_certificate` output is not properly tagged as `sensitive = true` to match it's upstream counterpart [here](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/blob/e342e4c1e9c6164c51456e1f40af006d3cc4410d/modules/beta-private-cluster/outputs.tf#L101).

This PR correctly sets the `ca_certificate` output as sensitive.

This becomes problematic when using the module from Terragrunt as you'll get the following error:
```
╷
│ Error: Output refers to sensitive values
│ 
│   on outputs.tf line 29:
│   29: output "ca_certificate" {
│ 
│ To reduce the risk of accidentally exporting sensitive data that was
│ intended to be only internal, Terraform requires that any root module
│ output containing sensitive data be explicitly marked as sensitive, to
│ confirm your intent.
│ 
│ If you do intend to export this data, annotate the output value as
│ sensitive by adding the following argument:
│     sensitive = true
╵
ERRO[0069] Terraform invocation failed in /Users/cjones/src/terragrunt-repo/development/sandboxes/cjones/scratch/gke-gha/.terragrunt-cache/HaQJoRguUiWbQzqk_oSxpSvldDk/1kW9xrwM9QZFpZ4HlxpmJGveo_g/modules/gh-runner-gke  prefix=[/Users/cjones/src/terragrunt-repo/development/sandboxes/cjones/scratch/gke-gha] 
ERRO[0069] 1 error occurred:
        * [/Users/cjones/src/terragrunt-repo/development/sandboxes/cjones/scratch/gke-gha/.terragrunt-cache/HaQJoRguUiWbQzqk_oSxpSvldDk/1kW9xrwM9QZFpZ4HlxpmJGveo_g/modules/gh-runner-gke] exit status 1
```
