### PR TITLE
feat: Update 'set' syntax in helm_resource to support v3

### DIFF
--- a/modules/gh-runner-gke/main.tf
+++ b/modules/gh-runner-gke/main.tf
@@ -127,23 +127,24 @@ resource "helm_release" "arc_runners_set" {
   chart     = "oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set"
   version   = var.arc_runners_version
 
-  set {
-    name  = "githubConfigSecret"
-    value = kubernetes_secret.gh_app_pre_defined_secret.metadata[0].name
-  }
-
-  set {
-    name  = "githubConfigUrl"
-    value = var.gh_config_url
-  }
-
-  dynamic "set" {
-    for_each = var.arc_container_mode == "" ? [] : [1]
-    content {
-      name  = "containerMode.type"
-      value = var.arc_container_mode
-    }
-  }
+  set = concat(
+    [
+      {
+        name  = "githubConfigSecret"
+        value = kubernetes_secret.gh_app_pre_defined_secret.metadata[0].name
+      },
+      {
+        name  = "githubConfigUrl"
+        value = var.gh_config_url
+      }
+    ],
+    var.arc_container_mode == "" ? [] : [
+      {
+        name  = "containerMode.type"
+        value = var.arc_container_mode
+      }
+    ]
+  )
 
   values = var.arc_runners_values
 }

--- a/modules/gh-runner-gke/versions.tf
+++ b/modules/gh-runner-gke/versions.tf
@@ -35,7 +35,7 @@ terraform {
 
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.0"
+      version = ">= 3.0"
     }
   }
 


### PR DESCRIPTION
- Changed the syntax for the 'set' blocks in helm_release resources to arguments. 
- Increase helm provider version to ">= 3.0"

Addresses the errors below:

```
│ Error: Unsupported block type

│ 

│   on .terraform/modules/runner-gke/modules/gh-runner-gke/main.tf line 130, in resource "helm_release" "arc_runners_set":

│  130:   set {

│ 

│ Blocks of type "set" are not expected here. Did you mean to define argument "set"? If so, use the equals sign to assign it a value.

╵

╷

│ Error: Unsupported block type

│ 

│   on .terraform/modules/runner-gke/modules/gh-runner-gke/main.tf line 135, in resource "helm_release" "arc_runners_set":

│  135:   set {

│ 

│ Blocks of type "set" are not expected here. Did you mean to define argument "set"? If so, use the equals sign to assign it a value.

╵

╷

│ Error: Unsupported block type

│ 

│   on .terraform/modules/runner-gke/modules/gh-runner-gke/main.tf line 140, in resource "helm_release" "arc_runners_set":

│  140:   dynamic "set" {

│ 

│ Blocks of type "set" are not expected here.


```