### PR TITLE
feat: custom disk size and type for GKE runner nodes

### DIFF
--- a/modules/gh-runner-gke/README.md
+++ b/modules/gh-runner-gke/README.md
@@ -85,6 +85,8 @@ This example shows how to deploy Self Hosted Runners on GKE that supports Docker
 | arc\_systems\_namespace | Namespace created for the ARC operator pods. | `string` | `"arc-systems"` | no |
 | cluster\_suffix | Name of the GitHub organization associated with this runner cluster. | `string` | `"arc"` | no |
 | create\_network | When set to true, VPC will be auto created | `bool` | `true` | no |
+| disk\_size\_gb | Size of the disk attached to each node, specified in GB. The smallest allowed disk size is 10GB | `number` | `100` | no |
+| disk\_type | Type of the disk attached to each node (e.g. 'pd-standard' or 'pd-ssd') | `string` | `"pd-standard"` | no |
 | enable\_private\_nodes | Whether nodes have internal IP addresses only. | `bool` | `false` | no |
 | gh\_app\_id | After creating the GitHub App, on the GitHub App's page, note the value for "App ID". | `string` | n/a | yes |
 | gh\_app\_installation\_id | You can find the app installation ID on the app installation page, which has the following URL format: `https://github.com/organizations/ORGANIZATION/settings/installations/INSTALLATION_ID` | `string` | n/a | yes |

--- a/modules/gh-runner-gke/main.tf
+++ b/modules/gh-runner-gke/main.tf
@@ -77,6 +77,8 @@ module "runner-cluster" {
       machine_type         = var.machine_type
       enable_private_nodes = var.enable_private_nodes
       spot                 = var.spot
+      disk_size_gb         = var.disk_size_gb
+      disk_type            = var.disk_type
     }
   ]
 }

--- a/modules/gh-runner-gke/metadata.yaml
+++ b/modules/gh-runner-gke/metadata.yaml
@@ -50,6 +50,16 @@ spec:
     type: bool
     default: true
     required: false
+  - name: disk_size_gb
+    description: Size of the disk attached to each node, specified in GB. The smallest allowed disk size is 10GB
+    type: number
+    default: 100
+    required: false
+  - name: disk_type
+    description: Type of the disk attached to each node (e.g. 'pd-standard' or 'pd-ssd')
+    type: string
+    default: pd-standard
+    required: false
   - name: gh_token
     description: Github token that is used for generating Self Hosted Runner Token
     type: string

--- a/modules/gh-runner-gke/variables.tf
+++ b/modules/gh-runner-gke/variables.tf
@@ -195,3 +195,15 @@ variable "spot" {
   description = "A boolean that represents whether the underlying node VMs are spot"
   default     = false
 }
+
+variable "disk_size_gb" {
+  type        = number
+  description = "Size of the disk attached to each node, specified in GB. The smallest allowed disk size is 10GB"
+  default     = 100
+}
+
+variable "disk_type" {
+  type        = string
+  description = "Type of the disk attached to each node (e.g. 'pd-standard' or 'pd-ssd')"
+  default     = "pd-standard"
+}


### PR DESCRIPTION
The default `disk_type`: `pd-standard` is pretty limiting for some of our high disk I/O workflows. It'd be great to have an option to use `pd-ssd` with a slightly lower storage size.

This PR enables consumer apps to specify `disk_size_gb` and `disk_type` for the GKE runner nodes when using the `gh-runner-gke` module.