### PR TITLE
feat(example): customize GH Actions runner for GFW deployment

### DIFF
--- a/examples/gh-runner-mig-native-simple/main.tf
+++ b/examples/gh-runner-mig-native-simple/main.tf
@@ -18,9 +18,13 @@ module "runner-mig" {
   source  = "terraform-google-modules/github-actions-runners/google//modules/gh-runner-mig-vm"
   version = "~> 5.0"
 
-  create_network = true
   project_id     = var.project_id
   repo_name      = var.repo_name
   repo_owner     = var.repo_owner
   gh_token       = var.gh_token
+
+  create_network = false
+  gh_runner_labels = ["self-hosted"]
+  machine_type = "e2-micro"
+  service_account = "terraform-deployer@${var.project_id}.iam.gserviceaccount.com"
 }


### PR DESCRIPTION
## Changes

Customize the `gh-runner-mig-native-simple` example to reflect GFW's deployment requirements:

- `create_network = false` — use existing VPC instead of creating a new one
- `gh_runner_labels = ["self-hosted"]` — apply self-hosted label
- `machine_type = "e2-micro"` — cost-optimized instance type
- `service_account` — bind to `terraform-deployer` service account

This makes the example more practical for real-world deployments that don't create new networks.